### PR TITLE
BAH-1082: Appointments-specific patient search endpoint.

### DIFF
--- a/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchController.java
+++ b/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchController.java
@@ -1,0 +1,64 @@
+package org.bahmni.module.bahmnicommons.web.v1_0.controller.search;
+
+import org.bahmni.module.bahmnicommons.contract.patient.PatientSearchParameters;
+import org.bahmni.module.bahmnicommons.contract.patient.response.PatientResponse;
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.RestUtil;
+import org.openmrs.module.webservices.rest.web.resource.impl.AlreadyPaged;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.BaseRestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Controller for REST web service access to
+ * the Search resource.
+ * To be used by the Bahmni appointment scheduling module.
+ */
+@Controller
+@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/appointments/search/patient")
+public class BahmniAppointmentsPatientSearchController extends BaseRestController {
+    
+    @RequestMapping(method = RequestMethod.GET)
+    @ResponseBody
+    public ResponseEntity<AlreadyPaged<PatientResponse>> search(HttpServletRequest request, HttpServletResponse response) throws ResponseException {
+
+        try {
+            RequestContext requestContext = RestUtil.getRequestContext(request, response);
+            PatientSearchParameters searchParameters = new PatientSearchParameters(requestContext);
+            List<Patient> patients = Context.getPatientService().getPatients(searchParameters.getName());
+                        
+            List<PatientResponse> patientResponseList = patients.stream().map(patient -> {
+                PatientResponse patientResponse = new PatientResponse();
+                patientResponse.setUuid(patient.getUuid());
+                patientResponse.setGivenName(patient.getGivenName());
+                patientResponse.setMiddleName(patient.getMiddleName());
+                patientResponse.setFamilyName(patient.getFamilyName());
+                patientResponse.setPersonId(patient.getPersonId());
+                patientResponse.setIdentifier(String.valueOf(patient.getPatientIdentifier()));
+                patientResponse.setGender(patient.getGender());
+                patientResponse.setBirthDate(patient.getBirthdate());
+                patientResponse.setDeathDate(patient.getDeathDate());
+                patientResponse.setDateCreated(patient.getDateCreated());
+                return patientResponse;
+            }).collect(Collectors.toList());
+            
+            AlreadyPaged alreadyPaged = new AlreadyPaged(requestContext, patientResponseList, false);
+            return new ResponseEntity(alreadyPaged,HttpStatus.OK);
+        }catch (IllegalArgumentException e){
+            return new ResponseEntity(RestUtil.wrapErrorResponse(e, e.getMessage()), HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchController.java
+++ b/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchController.java
@@ -48,8 +48,7 @@ public class BahmniAppointmentsPatientSearchController extends BaseRestControlle
         try {
             RequestContext requestContext = RestUtil.getRequestContext(request, response);
             PatientSearchParameters searchParameters = new PatientSearchParameters(requestContext);
-            String query = searchParameters.getIdentifier() != null ? searchParameters.getIdentifier() : searchParameters.getName();
-            
+
             if (searchParameters.getCustomAttribute() != null ||
                     searchParameters.getAddressFieldValue() != null ||
                     searchParameters.getPatientAttributes() != null ||
@@ -60,7 +59,8 @@ public class BahmniAppointmentsPatientSearchController extends BaseRestControlle
                     searchParameters.getLoginLocationUuid() != null) {
                 throw new IllegalRequestException("An unsupported search parameter was provided.");
             }
-            
+
+            String query = searchParameters.getIdentifier() != null ? searchParameters.getIdentifier() : searchParameters.getName();
             List<Patient> patients = patientService.getPatients(query);
                         
             List<PatientResponse> patientResponseList = patients.stream().map(patient -> {

--- a/bahmni-commons-omod/src/test/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchControllerTest.java
+++ b/bahmni-commons-omod/src/test/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchControllerTest.java
@@ -1,0 +1,76 @@
+package org.bahmni.module.bahmnicommons.web.v1_0.controller.search;
+
+import org.bahmni.module.bahmnicommons.BaseIntegrationTest;
+import org.bahmni.module.bahmnicommons.contract.patient.response.PatientResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.openmrs.*;
+import org.openmrs.api.PatientService;
+import org.openmrs.module.webservices.rest.web.resource.impl.AlreadyPaged;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+public class BahmniAppointmentsPatientSearchControllerTest extends BaseIntegrationTest {
+    
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @Mock
+    private HttpServletResponse httpServletResponse;
+
+    @Mock
+    private PatientService patientService;
+    
+    @Autowired
+    private BahmniAppointmentsPatientSearchController bahmniAppointmentsPatientSearchController;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+    
+    @Before
+    public void setUp() throws Exception {
+        bahmniAppointmentsPatientSearchController.setPatientService(patientService);
+        List<Patient> patients = new ArrayList<>();
+        Patient patient = new Patient();
+        patient.setPersonId(1);
+        patients.add(patient);
+        when(patientService.getPatients(Matchers.anyString())).thenReturn(patients);
+    }
+    
+    @Test
+    public void shouldSearchByIdentifier() {
+        when(httpServletRequest.getParameter("q")).thenReturn("GAN200001");
+        bahmniAppointmentsPatientSearchController.search(httpServletRequest, httpServletResponse);
+        verify(patientService, times(1)).getPatients("GAN200001");
+    }
+    
+    @Test
+    public void shouldSearchByName() {
+        when(httpServletRequest.getParameter("q")).thenReturn("John");
+        ResponseEntity<AlreadyPaged<PatientResponse>> response = bahmniAppointmentsPatientSearchController.search(httpServletRequest, httpServletResponse);
+        List<PatientResponse> patients = response.getBody().getPageOfResults();
+        verify(patientService, times(1)).getPatients("John");
+    }
+
+    @Test
+    public void shouldFailWithUnsupportedSearchParameter() {
+        when(httpServletRequest.getParameter("customAttribute")).thenReturn("testCustomAttribute");
+        exceptionRule.expect(ResponseException.class);
+        exceptionRule.expectMessage("An unsupported search parameter was provided.");
+        bahmniAppointmentsPatientSearchController.search(httpServletRequest, httpServletResponse);
+    }
+}

--- a/bahmni-commons-omod/src/test/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchControllerTest.java
+++ b/bahmni-commons-omod/src/test/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchControllerTest.java
@@ -36,14 +36,14 @@ public class BahmniAppointmentsPatientSearchControllerTest extends BaseIntegrati
     private PatientService patientService;
     
     @Autowired
-    private BahmniAppointmentsPatientSearchController bahmniAppointmentsPatientSearchController;
+    private BahmniAppointmentsPatientSearchController ctrl;
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
     
     @Before
     public void setUp() throws Exception {
-        bahmniAppointmentsPatientSearchController.setPatientService(patientService);
+        ctrl.setPatientService(patientService);
         List<Patient> patients = new ArrayList<>();
         Patient patient = new Patient();
         patient.setPersonId(1);
@@ -52,25 +52,25 @@ public class BahmniAppointmentsPatientSearchControllerTest extends BaseIntegrati
     }
     
     @Test
-    public void shouldSearchByIdentifier() {
+    public void search_shouldSearchByIdentifier() {
         when(httpServletRequest.getParameter("q")).thenReturn("GAN200001");
-        bahmniAppointmentsPatientSearchController.search(httpServletRequest, httpServletResponse);
+        ctrl.search(httpServletRequest, httpServletResponse);
         verify(patientService, times(1)).getPatients("GAN200001");
     }
     
     @Test
-    public void shouldSearchByName() {
+    public void search_shouldSearchByName() {
         when(httpServletRequest.getParameter("q")).thenReturn("John");
-        ResponseEntity<AlreadyPaged<PatientResponse>> response = bahmniAppointmentsPatientSearchController.search(httpServletRequest, httpServletResponse);
+        ResponseEntity<AlreadyPaged<PatientResponse>> response = ctrl.search(httpServletRequest, httpServletResponse);
         List<PatientResponse> patients = response.getBody().getPageOfResults();
         verify(patientService, times(1)).getPatients("John");
     }
 
     @Test
-    public void shouldFailWithUnsupportedSearchParameter() {
+    public void search_shouldFailWithUnsupportedSearchParameter() {
         when(httpServletRequest.getParameter("customAttribute")).thenReturn("testCustomAttribute");
         exceptionRule.expect(ResponseException.class);
         exceptionRule.expectMessage("An unsupported search parameter was provided.");
-        bahmniAppointmentsPatientSearchController.search(httpServletRequest, httpServletResponse);
+        ctrl.search(httpServletRequest, httpServletResponse);
     }
 }


### PR DESCRIPTION
#### Ticket:
https://bahmni.atlassian.net/browse/BAH-1082

#### What I've done:
- Created new controller to allow patient search using endpoint "/appointments/search/patient"
- New controller allows searching by patient name and identifier (as required by appointments module)
- New controller relies on core openmrs services, hence triggering the datafilter module
- Previous existing controller, filtering features, and endpoint "/bahmnicommons/search/patient" were kept with no changes