### PR TITLE
Adopt current OpenMRS convention for resource versioning

### DIFF
--- a/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/search/BahmniLocationSearchHandler.java
+++ b/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/search/BahmniLocationSearchHandler.java
@@ -30,7 +30,7 @@ public class BahmniLocationSearchHandler implements SearchHandler{
 
     @Override
     public SearchConfig getSearchConfig() {
-        return new SearchConfig("byTags", RestConstants.VERSION_1 + "/location", Arrays.asList("1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*"),
+        return new SearchConfig("byTags", RestConstants.VERSION_1 + "/location", Arrays.asList("1.9.* - 9.*"),
                 new SearchQuery.Builder("Allows you to find locations by tags attached to the location").withRequiredParameters("tags").build());
 
     }


### PR DESCRIPTION
This just bumps things so that the BahmniLocationSearchHandler is no longer tied to specific OpenMRS versions... at least until we get to version 10. The syntax is an unfortunate restriction necessary to keep backwards compatibility with previous versions of OpenMRS.