### PR TITLE
BAH-3228 | Add. Total Count Value In Lucene Search

### DIFF
--- a/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchController.java
+++ b/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniAppointmentsPatientSearchController.java
@@ -79,7 +79,7 @@ public class BahmniAppointmentsPatientSearchController extends BaseRestControlle
                 return patientResponse;
             }).collect(Collectors.toList());
             
-            AlreadyPaged alreadyPaged = new AlreadyPaged(requestContext, patientResponseList, false);
+            AlreadyPaged alreadyPaged = new AlreadyPaged(requestContext, patientResponseList, false, (long) patientResponseList.size());
             return new ResponseEntity(alreadyPaged,HttpStatus.OK);
         }catch (IllegalArgumentException e){
             return new ResponseEntity(RestUtil.wrapErrorResponse(e, e.getMessage()), HttpStatus.BAD_REQUEST);

--- a/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniPatientSearchController.java
+++ b/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/controller/search/BahmniPatientSearchController.java
@@ -47,7 +47,7 @@ public class BahmniPatientSearchController extends BaseRestController {
         PatientSearchParameters searchParameters = new PatientSearchParameters(requestContext);
         try {
             List<PatientResponse> patients = bahmniPatientService.search(searchParameters);
-            AlreadyPaged alreadyPaged = new AlreadyPaged(requestContext, patients, false);
+            AlreadyPaged alreadyPaged = new AlreadyPaged(requestContext, patients, false, (long) patients.size());
             return new ResponseEntity(alreadyPaged,HttpStatus.OK);
         }catch (IllegalArgumentException e){
             return new ResponseEntity(RestUtil.wrapErrorResponse(e, e.getMessage()), HttpStatus.BAD_REQUEST);
@@ -62,7 +62,7 @@ public class BahmniPatientSearchController extends BaseRestController {
         PatientSearchParameters searchParameters = new PatientSearchParameters(requestContext);
         try {
             List<PatientResponse> patients = bahmniPatientService.luceneSearch(searchParameters);
-            AlreadyPaged alreadyPaged = new AlreadyPaged(requestContext, patients, false);
+            AlreadyPaged alreadyPaged = new AlreadyPaged(requestContext, patients, false, (long) patients.size());
             return new ResponseEntity(alreadyPaged,HttpStatus.OK);
         }catch (IllegalArgumentException e){
             return new ResponseEntity(RestUtil.wrapErrorResponse(e, e.getMessage()), HttpStatus.BAD_REQUEST);

--- a/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/search/BahmniLocationSearchHandler.java
+++ b/bahmni-commons-omod/src/main/java/org/bahmni/module/bahmnicommons/web/v1_0/search/BahmniLocationSearchHandler.java
@@ -50,6 +50,6 @@ public class BahmniLocationSearchHandler implements SearchHandler{
         if("ANY".equals(operator)){
             locations = locationService.getLocationsHavingAnyTag(tags);
         }
-        return new AlreadyPaged<>(requestContext, locations, false);
+        return new AlreadyPaged<>(requestContext, locations, false, (long) locations.size());
     }
 }


### PR DESCRIPTION
JIRA -> [BAH-3228](https://bahmni.atlassian.net/browse/BAH-3228)

This PR addresses the issue in the Bahmni Lucene search API. Currently, it returns "null" for the totalCount attribute in its response, even when it should contain a valid, non-null, and positive number of matching patients. This occurred due to a missing parameter in the AlreadyPaged [constructor](https://github.com/openmrs/openmrs-module-webservices.rest/blob/e4ae0d702eb7c060928dd06cccb1856f4d928aa1/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/AlreadyPaged.java#L38).

The issue has been successfully resolved in this PR.

Additionally we have updated the same changes wherever the AlreadyPaged constructor is being called.