### PR TITLE
BAH-3526 | Fix. Lucene query for patient name to perform AND search

### DIFF
--- a/bahmni-commons-api/src/main/java/org/bahmni/module/bahmnicommons/api/dao/impl/PatientDaoImpl.java
+++ b/bahmni-commons-api/src/main/java/org/bahmni/module/bahmnicommons/api/dao/impl/PatientDaoImpl.java
@@ -14,6 +14,7 @@ import org.bahmni.module.bahmnicommons.api.contract.patient.search.PatientSearch
 import org.bahmni.module.bahmnicommons.api.visitlocation.BahmniVisitLocationServiceImpl;
 import org.bahmni.module.bahmnicommons.api.dao.PatientDao;
 import org.hibernate.SQLQuery;
+import org.hibernate.search.query.dsl.MustJunction;
 import org.openmrs.ProgramAttributeType;
 import org.hibernate.Query;
 import org.hibernate.Session;
@@ -173,11 +174,27 @@ public class PatientDaoImpl implements PatientDao {
     private List<PersonName> getPatientsByName(String name, Integer offset, Integer length) {
         FullTextSession fullTextSession = Search.getFullTextSession(sessionFactory.getCurrentSession());
         QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder().forEntity(PersonName.class).get();
-        name = name.replace('%', '*');
-
         org.apache.lucene.search.Query nonVoidedNames = queryBuilder.keyword().onField("voided").matching(false).createQuery();
         org.apache.lucene.search.Query nonVoidedPersons = queryBuilder.keyword().onField("person.voided").matching(false).createQuery();
 
+
+        MustJunction mustJunction = queryBuilder.bool()
+                .must(nonVoidedNames)
+                .must(nonVoidedPersons);
+        String[] names = name.trim().split(" ");
+        for(int i=0; i<names.length;i++) {
+            BooleanJunction booleanJunction = queryInAllNameTypes(names[i].replace('%', '*'), queryBuilder);
+            mustJunction.must(booleanJunction.createQuery());
+        }
+
+        org.apache.lucene.search.Query booleanQuery =mustJunction.createQuery();
+                FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery(booleanQuery, PersonName.class);
+        fullTextQuery.setFirstResult(offset);
+        fullTextQuery.setMaxResults(length);
+        return (List<PersonName>) fullTextQuery.list();
+    }
+
+    private BooleanJunction queryInAllNameTypes(String name, QueryBuilder queryBuilder) {
         List<String> patientNames = getPatientNames();
 
         BooleanJunction nameShouldJunction = queryBuilder.bool();
@@ -186,16 +203,7 @@ public class PatientDaoImpl implements PatientDao {
                     .onField(patientName).matching("*" + name.toLowerCase() + "*").createQuery();
             nameShouldJunction.should(nameQuery);
         }
-
-        org.apache.lucene.search.Query booleanQuery = queryBuilder.bool()
-                .must(nonVoidedNames)
-                .must(nonVoidedPersons)
-                .must(nameShouldJunction.createQuery())
-                .createQuery();
-        FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery(booleanQuery, PersonName.class);
-        fullTextQuery.setFirstResult(offset);
-        fullTextQuery.setMaxResults(length);
-        return (List<PersonName>) fullTextQuery.list();
+        return nameShouldJunction;
     }
 
     private List<String> getPatientNames() {

--- a/bahmni-commons-api/src/test/java/org/bahmni/module/bahmnicommons/api/dao/impl/PatientDaoImplLuceneIT.java
+++ b/bahmni-commons-api/src/test/java/org/bahmni/module/bahmnicommons/api/dao/impl/PatientDaoImplLuceneIT.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 
 import static junit.framework.Assert.*;
+import static junit.framework.Assert.assertEquals;
 
 public class PatientDaoImplLuceneIT extends BaseIntegrationTest {
     @Autowired
@@ -284,6 +285,25 @@ public class PatientDaoImplLuceneIT extends BaseIntegrationTest {
         patients = patientDao.getPatientsUsingLuceneSearch("NAT100010", "uniqueStringSoNoResultsFromPatientNames", null, "city_village", "",
                 100, 0, null, "", null, addressResultFields, null, "c36006e5-9fbb-4f20-866b-0ece245615a1", false, true);
         assertEquals(1, patients.size());
+    }
+
+    @Test
+    public void shouldSearchByAnyPatientFullName() {
+        String[] addressResultFields = {"city_village"};
+        List<PatientResponse> patients = patientDao.getPatientsUsingLuceneSearch("Horatio Peeter Sinha", "Horatio Peeter Sinha", null, "city_village", "",
+                100, 0, null, "", null, addressResultFields, null, "c36006e5-9fbb-4f20-866b-0ece245615a1", false, true);
+        assertNotNull(patients);
+        assertEquals(1, patients.size());
+        PatientResponse patient = patients.get(0);
+        assertEquals("341b4e41-790c-484f-b6ed-71dc8da222db", patient.getUuid());
+        assertEquals("GAN200001", patient.getIdentifier());
+        assertEquals("Horatio", patient.getGivenName());
+        assertEquals("Peeter", patient.getMiddleName());
+        assertEquals("Sinha", patient.getFamilyName());
+        assertEquals("M", patient.getGender());
+        assertEquals("{\"city_village\" : \"Ramgarh\"}", patient.getAddressFieldValue());
+        assertEquals(null, patient.getDeathDate());
+        assertEquals("{\"National ID\" : \"NAT100010\"}", patient.getExtraIdentifiers());
     }
 
 }


### PR DESCRIPTION
JIRA -> [BAH-3526](https://bahmni.atlassian.net/browse/BAH-3526), [BAH-3267](https://bahmni.atlassian.net/browse/BAH-3267)

In this PR, the following changes have been made : 
1. Enhanced the API to accept spaces in the OT and appointment module & All tab.
2. Resolved the issue of patient search failures after using the backspace key.

The current Lucene search API does not accommodate spaces, leading to patient search failures when their full names are used. These enhancements aim to improve the search functionality, ensuring smoother patient searches by accommodating spaces in the search query.