### PR TITLE
BAH-3635 | Add. Match Type Based Lucene Search

### DIFF
--- a/bahmni-commons-api/pom.xml
+++ b/bahmni-commons-api/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+        </dependency>
 
     </dependencies>
 

--- a/bahmni-commons-api/src/test/java/org/bahmni/module/bahmnicommons/api/dao/impl/PatientDaoImplLuceneIT.java
+++ b/bahmni-commons-api/src/test/java/org/bahmni/module/bahmnicommons/api/dao/impl/PatientDaoImplLuceneIT.java
@@ -3,10 +3,8 @@ package org.bahmni.module.bahmnicommons.api.dao.impl;
 import org.bahmni.module.bahmnicommons.api.BaseIntegrationTest;
 import org.bahmni.module.bahmnicommons.api.contract.patient.response.PatientResponse;
 import org.bahmni.module.bahmnicommons.api.dao.PatientDao;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -20,6 +18,10 @@ public class PatientDaoImplLuceneIT extends BaseIntegrationTest {
     private PatientDao patientDao;
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
+
+    @Rule
+    public final EnvironmentVariables environmentVariables
+            = new EnvironmentVariables();
 
     @Before
     public void setUp() throws Exception {
@@ -370,17 +372,71 @@ public class PatientDaoImplLuceneIT extends BaseIntegrationTest {
                 100, 0, null, "", null, addressResultFields, null, "c36006e5-9fbb-4f20-866b-0ece245615a1", false, true);
         assertNotNull(patients);
         assertEquals(2, patients.size());
+        PatientResponse patientResponse1 = patients.get(0);
+        assertEquals("6817dcdc-d623-11ee-a506-0242ac120002", patientResponse1.getUuid());
+        assertEquals("PAN200065", patientResponse1.getIdentifier());
+        assertEquals("Francis", patientResponse1.getGivenName());
+        assertEquals("Scott", patientResponse1.getMiddleName());
+        assertEquals("Fitzgerald", patientResponse1.getFamilyName());
+        PatientResponse patientResponse2 = patients.get(1);
+        assertEquals("6e318c2a-d624-11ee-a506-0242ac120002", patientResponse2.getUuid());
+        assertEquals("PAN200066", patientResponse2.getIdentifier());
+        assertEquals("F", patientResponse2.getGivenName());
+        assertEquals("Scott", patientResponse2.getMiddleName());
+        assertEquals("Fitzgerald", patientResponse2.getFamilyName());
+    }
+
+    @Test
+    public void shouldSearchPatientsWithExactMatchWhenModeIsEXACT() throws Exception {
+        environmentVariables.set("LUCENE_MATCH_TYPE","EXACT");
+        String[] addressResultFields = {"city_village"};
+        List<PatientResponse> patients = patientDao.getPatientsUsingLuceneSearch("F Scott Fitzgerald", "F Scott Fitzgerald", null, "city_village", null,
+                100, 0, null, "", null, addressResultFields, null, "c36006e5-9fbb-4f20-866b-0ece245615a1", false, true);
+        assertNotNull(patients);
+        assertEquals(1, patients.size());
+        PatientResponse patientResponse = patients.get(0);
+        assertEquals("6e318c2a-d624-11ee-a506-0242ac120002", patientResponse.getUuid());
+        assertEquals("PAN200066", patientResponse.getIdentifier());
+        assertEquals("F", patientResponse.getGivenName());
+        assertEquals("Scott", patientResponse.getMiddleName());
+        assertEquals("Fitzgerald", patientResponse.getFamilyName());
+    }
+
+    @Test
+    public void shouldSearchPatientsWithMatchAnywhereWhenModeIsANYWHERE() throws Exception {
+        environmentVariables.set("LUCENE_MATCH_TYPE","ANYWHERE");
+        String[] addressResultFields = {"city_village"};
+        List<PatientResponse> patients = patientDao.getPatientsUsingLuceneSearch("Niel", "Niel", null, "city_village", null,
+                100, 0, null, "", null, addressResultFields, null, "c36006e5-9fbb-4f20-866b-0ece245615a1", false, true);
+        assertNotNull(patients);
+        assertEquals(2, patients.size());
         PatientResponse patient1 = patients.get(0);
-        assertEquals("6e318c2a-d624-11ee-a506-0242ac120002", patient1.getUuid());
-        assertEquals("PAN200066", patient1.getIdentifier());
-        assertEquals("F", patient1.getGivenName());
-        assertEquals("Scott", patient1.getMiddleName());
-        assertEquals("Fitzgerald", patient1.getFamilyName());
+        assertEquals("a83ae586-d6bc-11ee-a506-0242ac120002", patient1.getUuid());
+        assertEquals("PAN200067", patient1.getIdentifier());
+        assertEquals("Daniel", patient1.getGivenName());
+        assertEquals("Day", patient1.getMiddleName());
+        assertEquals("Lewis", patient1.getFamilyName());
         PatientResponse patient2 = patients.get(1);
-        assertEquals("6817dcdc-d623-11ee-a506-0242ac120002", patient2.getUuid());
-        assertEquals("PAN200065", patient2.getIdentifier());
-        assertEquals("Francis", patient2.getGivenName());
-        assertEquals("Scott", patient2.getMiddleName());
-        assertEquals("Fitzgerald", patient2.getFamilyName());
+        assertEquals("8bf18320-d6bd-11ee-a506-0242ac120002", patient2.getUuid());
+        assertEquals("PAN200068", patient2.getIdentifier());
+        assertEquals("Nielsen", patient2.getGivenName());
+        assertEquals("William", patient2.getMiddleName());
+        assertEquals("Leslie", patient2.getFamilyName());
+    }
+
+    @Test
+    public void shouldSearchPatientsNameWhichStartsWithSearchTermWhenModeIsSTART() throws Exception {
+        environmentVariables.set("LUCENE_MATCH_TYPE","START");
+        String[] addressResultFields = {"city_village"};
+        List<PatientResponse> patients = patientDao.getPatientsUsingLuceneSearch("Niel", "Niel", null, "city_village", null,
+                100, 0, null, "", null, addressResultFields, null, "c36006e5-9fbb-4f20-866b-0ece245615a1", false, true);
+        assertNotNull(patients);
+        assertEquals(1, patients.size());
+        PatientResponse patientResponse = patients.get(0);
+        assertEquals("8bf18320-d6bd-11ee-a506-0242ac120002", patientResponse.getUuid());
+        assertEquals("PAN200068", patientResponse.getIdentifier());
+        assertEquals("Nielsen", patientResponse.getGivenName());
+        assertEquals("William", patientResponse.getMiddleName());
+        assertEquals("Leslie", patientResponse.getFamilyName());
     }
 }

--- a/bahmni-commons-api/src/test/resources/apiTestData.xml
+++ b/bahmni-commons-api/src/test/resources/apiTestData.xml
@@ -20,6 +20,10 @@
     <person person_id="1064" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-16 15:46:47.0" voided="false" uuid="a797b93e-d61b-11ee-a506-0242ac120002"/>
     <person person_id="1065" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-16 15:46:47.0" voided="false" uuid="6817dcdc-d623-11ee-a506-0242ac120002"/>
     <person person_id="1066" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-16 15:46:47.0" voided="false" uuid="6e318c2a-d624-11ee-a506-0242ac120002"/>
+    <person person_id="1067" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-16 15:46:47.0" voided="false" uuid="a83ae586-d6bc-11ee-a506-0242ac120002"/>
+    <person person_id="1068" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-16 15:46:47.0" voided="false" uuid="8bf18320-d6bd-11ee-a506-0242ac120002"/>
+    <person person_id="1069" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-16 15:46:47.0" voided="false" uuid="c8f8c16c-d6f3-11ee-a506-0242ac120002"/>
+    <person person_id="1070" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2008-08-16 15:46:47.0" voided="false" uuid="a4a47fa8-d6f4-11ee-a506-0242ac120002"/>
 
     <patient patient_id="1024" creator="1" date_created="2005-09-22 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:29:59.0" voided="false" void_reason=""/>
     <patient patient_id="1025" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:31.0" voided="false" void_reason=""/>
@@ -40,6 +44,10 @@
     <patient patient_id="1064" creator="1" date_created="2006-01-19 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
     <patient patient_id="1065" creator="1" date_created="2006-01-19 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
     <patient patient_id="1066" creator="1" date_created="2006-01-19 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
+    <patient patient_id="1067" creator="1" date_created="2006-01-19 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
+    <patient patient_id="1068" creator="1" date_created="2006-01-19 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
+    <patient patient_id="1069" creator="1" date_created="2006-01-19 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
+    <patient patient_id="1070" creator="1" date_created="2006-01-19 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
 
     <person_name person_name_id="1024" preferred="true" person_id="1024" prefix="Mr." given_name="Horatio" middle_name="Test" family_name="Banka" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="399e3a7b-6482-487d-94ce-c07bb3ca3cca"/>
     <person_name person_name_id="1025" preferred="true" person_id="1025" prefix="Mr." given_name="Horatio" middle_name="Peeter" family_name="Sinha" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="399e3a7b-6482-487d-94ce-c07bb3ca3ccb"/>
@@ -84,6 +92,10 @@
     <person_name person_name_id="1064" preferred="false" person_id="1064" prefix="Mr." given_name="Rahul" middle_name="Dev" family_name="B" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="729e5d82-d61b-11ee-a506-0242ac120002"/>
     <person_name person_name_id="1065" preferred="false" person_id="1065" prefix="Mr." given_name="Francis" middle_name="Scott" family_name="Fitzgerald" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="af01c694-d623-11ee-a506-0242ac120002"/>
     <person_name person_name_id="1066" preferred="false" person_id="1066" prefix="Mr." given_name="F" middle_name="Scott" family_name="Fitzgerald" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="5989bc0c-d624-11ee-a506-0242ac120002"/>
+    <person_name person_name_id="1067" preferred="false" person_id="1067" prefix="Mr." given_name="Daniel" middle_name="Day" family_name="Lewis" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="de1e32f2-d6bc-11ee-a506-0242ac120002"/>
+    <person_name person_name_id="1068" preferred="false" person_id="1068" prefix="Mr." given_name="Nielsen" middle_name="William" family_name="Leslie" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="edad0ecc-d6bd-11ee-a506-0242ac120002"/>
+    <person_name person_name_id="1069" preferred="false" person_id="1069" prefix="Mr." given_name="Carter" middle_name="Adams" family_name="Davis" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="fa2faef8-d6f3-11ee-a506-0242ac120002"/>
+    <person_name person_name_id="1070" preferred="false" person_id="1070" prefix="Mr." given_name="Charter" middle_name="Addams" family_name="Davies" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" void_reason="" uuid="ca9b8418-d6f4-11ee-a506-0242ac120002"/>
 
     <person_attribute_type person_attribute_type_id="1" name="caste" description="caste" format="org.openmrs.Concept" foreign_key="90" searchable="true" creator="1" date_created="2007-05-04 09:59:23.0" retired="false" uuid="b3b6d540-a32e-44c7-91b3-292d976675ab" sort_weight="1"/>
     <person_attribute_type person_attribute_type_id="201" name="givenNameLocal" description="first name" format="java.lang.String" searchable="true" creator="1" date_created="2007-05-04 09:59:23.0" retired="false" uuid="b3b6d900-a32e-44c7-91b3-292d976675ab" sort_weight="1"/>
@@ -127,6 +139,10 @@
     <person_attribute person_attribute_id="304" person_id="1064" value="1064" person_attribute_type_id="1" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="559e5a78-d61d-11ee-a506-0242ac120002"/>
     <person_attribute person_attribute_id="305" person_id="1065" value="1065" person_attribute_type_id="1" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="99cb87f8-d626-11ee-a506-0242ac120002"/>
     <person_attribute person_attribute_id="306" person_id="1066" value="1066" person_attribute_type_id="1" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="9fbf4726-d626-11ee-a506-0242ac120002"/>
+    <person_attribute person_attribute_id="307" person_id="1067" value="1067" person_attribute_type_id="1" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="f00b65f2-d6bc-11ee-a506-0242ac120002"/>
+    <person_attribute person_attribute_id="308" person_id="1068" value="1068" person_attribute_type_id="1" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="fa00196c-d6bd-11ee-a506-0242ac120002"/>
+    <person_attribute person_attribute_id="309" person_id="1069" value="1069" person_attribute_type_id="1" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="5c3132c0-d6f4-11ee-a506-0242ac120002"/>
+    <person_attribute person_attribute_id="310" person_id="1070" value="1070" person_attribute_type_id="1" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="e109c322-d6f4-11ee-a506-0242ac120002"/>
 
     <location location_id="1" name="Unknown_Location" description=" 0" creator="1" retired="0" retired_by=" 0"  uuid="8d6c993e-c2cc-11de-8d13-0010c6dffd0f" date_created="2005-09-22 00:00:00"/>
     <location location_id="2" name="Ganiyari" description="Ganiyari hospital" creator="1" retired="0" retired_by=" 0"  uuid="8d6c993e-c2cc-11de-8d13-0040c6dffd0f" date_created="2005-09-22 00:00:00" />
@@ -160,6 +176,10 @@
     <person_address person_address_id="6" person_id="1064" preferred="true" city_village="Ramgarh" state_province="Madhya Pradesh" creator="1" date_created="2006-11-24 10:50:16.0" voided="false" void_reason="" county_district="Dindori" address3="Dindori"/>
     <person_address person_address_id="7" person_id="1065" preferred="true" city_village="Ramgarh" state_province="Madhya Pradesh" creator="1" date_created="2006-11-24 10:50:16.0" voided="false" void_reason="" county_district="Dindori" address3="Dindori"/>
     <person_address person_address_id="8" person_id="1066" preferred="true" city_village="Ramgarh" state_province="Madhya Pradesh" creator="1" date_created="2006-11-24 10:50:16.0" voided="false" void_reason="" county_district="Dindori" address3="Dindori"/>
+    <person_address person_address_id="9" person_id="1067" preferred="true" city_village="Ramgarh" state_province="Madhya Pradesh" creator="1" date_created="2006-11-24 10:50:16.0" voided="false" void_reason="" county_district="Dindori" address3="Dindori"/>
+    <person_address person_address_id="10" person_id="1068" preferred="true" city_village="Ramgarh" state_province="Madhya Pradesh" creator="1" date_created="2006-11-24 10:50:16.0" voided="false" void_reason="" county_district="Dindori" address3="Dindori"/>
+    <person_address person_address_id="11" person_id="1069" preferred="true" city_village="Ramgarh" state_province="Madhya Pradesh" creator="1" date_created="2006-11-24 10:50:16.0" voided="false" void_reason="" county_district="Dindori" address3="Dindori"/>
+    <person_address person_address_id="12" person_id="1070" preferred="true" city_village="Ramgarh" state_province="Madhya Pradesh" creator="1" date_created="2006-11-24 10:50:16.0" voided="false" void_reason="" county_district="Dindori" address3="Dindori"/>
 
     <global_property property="bahmni.primaryIdentifierType" property_value="1a339fe9-38bc-4ab3-b180-320988c0b968" uuid="9885827e-26fe-102b-80cb-2017a47871b3"/>
     <global_property property="bahmni.extraPatientIdentifierTypes" property_value="b0d10dc0-d8ce-11e3-9c1a-080020zd9a66,c0e31dc0-d8ee-11e3-9c1a-081220zd9a66" uuid="9885827e-26fe-102b-80cb-2017a4ls71b3"/>
@@ -191,9 +211,13 @@
     <patient_identifier date_created="2009-09-22 00:00:00" patient_identifier_id="26" patient_id ="1062" identifier="PAN200062" identifier_type="8"  creator="1"  uuid="8387b8b6-9142-49da-8ac7-6e2b9a8dba21" preferred="0" voided="0" />
     <patient_identifier date_created="2009-09-22 00:00:00" patient_identifier_id="27" patient_id ="1063" identifier="PAN200063" identifier_type="8"  creator="1"  uuid="9f5fdc74-d61b-11ee-a506-0242ac120002" preferred="0" voided="0" />
     <patient_identifier date_created="2009-09-22 00:00:00" patient_identifier_id="28" patient_id ="1064" identifier="PAN200064" identifier_type="8"  creator="1"  uuid="a797b93e-d61b-11ee-a506-0242ac120002" preferred="0" voided="0" />
+    <patient_identifier date_created="2005-09-22 00:00:00" patient_identifier_id="29" patient_id ="161" identifier="GAN200004-2005-09-22-00-00-123" identifier_type="1"  creator="1"  uuid="8387b8b6-9142-49da-8ac7-6e2b9a8dba20" preferred="1" voided="0" />
     <patient_identifier date_created="2005-09-22 00:00:00" patient_identifier_id="30" patient_id ="1065" identifier="PAN200065" identifier_type="1"  creator="1"  uuid="6817dcdc-d623-11ee-a506-0242ac120002" preferred="1" voided="0" />
     <patient_identifier date_created="2005-09-22 00:00:00" patient_identifier_id="31" patient_id ="1066" identifier="PAN200066" identifier_type="1"  creator="1"  uuid="6e318c2a-d624-11ee-a506-0242ac120002" preferred="1" voided="0" />
-    <patient_identifier date_created="2005-09-22 00:00:00" patient_identifier_id="29" patient_id ="161" identifier="GAN200004-2005-09-22-00-00-123" identifier_type="1"  creator="1"  uuid="8387b8b6-9142-49da-8ac7-6e2b9a8dba20" preferred="1" voided="0" />
+    <patient_identifier date_created="2005-09-22 00:00:00" patient_identifier_id="32" patient_id ="1067" identifier="PAN200067" identifier_type="1"  creator="1"  uuid="a83ae586-d6bc-11ee-a506-0242ac120002" preferred="1" voided="0" />
+    <patient_identifier date_created="2005-09-22 00:00:00" patient_identifier_id="33" patient_id ="1068" identifier="PAN200068" identifier_type="1"  creator="1"  uuid="8bf18320-d6bd-11ee-a506-0242ac120002" preferred="1" voided="0" />
+    <patient_identifier date_created="2005-09-22 00:00:00" patient_identifier_id="34" patient_id ="1069" identifier="PAN200069" identifier_type="1"  creator="1"  uuid="c8f8c16c-d6f3-11ee-a506-0242ac120002" preferred="1" voided="0" />
+    <patient_identifier date_created="2005-09-22 00:00:00" patient_identifier_id="35" patient_id ="1070" identifier="PAN200070" identifier_type="1"  creator="1"  uuid="a4a47fa8-d6f4-11ee-a506-0242ac120002" preferred="1" voided="0" />
 
     <visit visit_id="1" date_started="2005-09-22 00:00:00" date_created="2005-09-22 00:00:00" patient_id="2" visit_type_id="1" date_stopped="2013-05-08 04:08:16"  location_id="2" creator="1"  uuid="ad41fb41-a41a-4ad6-8835-2f59099acf5a" voided="0"/>
     <visit visit_id="2" date_started="2005-09-22 00:00:00" date_created="2005-09-22 00:00:00" patient_id="6" visit_type_id="1"  location_id="2" creator="1"  uuid="d794516f-210d-4c4e-8978-467d97969f31" voided="0"/>


### PR DESCRIPTION
JIRA -> [BAH-3635](https://bahmni.atlassian.net/browse/BAH-3635)

In this pull request, the Lucene search functionality has undergone configuration enhancements. Now, the search results vary based on the `LUCENE_MATCH_TYPE` environment variable, providing distinct outcomes for different match types:

**`EXACT`** : Only exact matches will be considered.
**`START`** : Matches that commence with the search term will be considered.
**`ANYWHERE`** : All search results containing the search term anywhere in the text will be considered.


| LUCENE_MATCH_TYPE | Search Term | Daniel  | Nielsen  |
| -----------------------  | ------------- | ------  |-------- |
| EXACT             | Daniel       | True   | False  |
|                          | Nielsen     | False  | True   | 
| START              | Niel           | False  | True   | 
|                          | niel            | False  | True   | 
| ANYWHERE     | Niel           | True   | True   |
|                           | niel           | True   | True   |