### PR TITLE
BAH-4173 | Fix. Flaky test due to age calculation

### DIFF
--- a/bahmni-commons-api/src/test/java/org/bahmni/module/bahmnicommons/api/contract/patient/mapper/PatientResponseMapperTest.java
+++ b/bahmni-commons-api/src/test/java/org/bahmni/module/bahmnicommons/api/contract/patient/mapper/PatientResponseMapperTest.java
@@ -76,12 +76,12 @@ public class PatientResponseMapperTest {
 
         PatientResponse patientResponse = patientResponseMapper.map(patient, null, null, null, null);
 
-        Assert.assertEquals(patientResponse.getPersonId(), 12);
-        Assert.assertEquals(patientResponse.getBirthDate(), birthDate);
-        Assert.assertEquals(patientResponse.getAge(), Integer.toString(expectedAge));
-        Assert.assertEquals(patientResponse.getUuid(), "someUUid");
-        Assert.assertEquals(patientResponse.getIdentifier(), "FAN007");
-        Assert.assertEquals(patientResponse.getExtraIdentifiers(), "{\"test\" : \"Extra009\"}");
+        Assert.assertEquals(12, patientResponse.getPersonId());
+        Assert.assertEquals(birthDate, patientResponse.getBirthDate());
+        Assert.assertEquals(Integer.toString(expectedAge), patientResponse.getAge());
+        Assert.assertEquals("someUUid", patientResponse.getUuid());
+        Assert.assertEquals("FAN007", patientResponse.getIdentifier());
+        Assert.assertEquals("{\"test\" : \"Extra009\"}", patientResponse.getExtraIdentifiers());
     }
 
     @Test
@@ -92,7 +92,7 @@ public class PatientResponseMapperTest {
         String[] patientResultFields = {"givenNameLocal"};
         PatientResponse patientResponse = patientResponseMapper.map(patient, null, patientResultFields, null, null);
 
-        Assert.assertEquals(patientResponse.getCustomAttribute(),"{\"givenNameLocal\" : \"someName\"}");
+        Assert.assertEquals("{\"givenNameLocal\" : \"someName\"}", patientResponse.getCustomAttribute());
     }
 
     @Test
@@ -117,7 +117,7 @@ public class PatientResponseMapperTest {
 
         PatientResponse patientResponse = patientResponseMapper.map(patient, null, patientResultFields, null, null);
 
-        Assert.assertEquals(patientResponse.getCustomAttribute(),"{\"occupation\" : \"FSN\"}");
+        Assert.assertEquals("{\"occupation\" : \"FSN\"}", patientResponse.getCustomAttribute());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class PatientResponseMapperTest {
         String[] patientResultFields = {"familyNameLocal"};
         PatientResponse patientResponse = patientResponseMapper.map(patient, null, patientResultFields, null, null);
 
-        Assert.assertEquals(patientResponse.getCustomAttribute(),"{\"familyNameLocal\" : \"so\\\"me\\\\Name\"}");
+        Assert.assertEquals("{\"familyNameLocal\" : \"so\\\"me\\\\Name\"}", patientResponse.getCustomAttribute());
     }
 
     @Test
@@ -138,7 +138,7 @@ public class PatientResponseMapperTest {
         patient.setAddresses(Sets.newSet(personAddress));
 
         PatientResponse patientResponse = patientResponseMapper.map(patient, null, null, new String[]{"address_2"}, null);
-        Assert.assertEquals(patientResponse.getAddressFieldValue(),"{\"address_2\" : \"someAddress\"}");
+        Assert.assertEquals("{\"address_2\" : \"someAddress\"}", patientResponse.getAddressFieldValue());
 
     }
 
@@ -146,8 +146,8 @@ public class PatientResponseMapperTest {
     public void shouldMapVisitSummary() throws Exception {
 
         PatientResponse patientResponse = patientResponseMapper.map(patient, null, null, null, null);
-        Assert.assertEquals(patientResponse.getActiveVisitUuid(),"someLocationUUid");
-        Assert.assertEquals(patientResponse.getHasBeenAdmitted(), Boolean.FALSE);
+        Assert.assertEquals("someLocationUUid", patientResponse.getActiveVisitUuid());
+        Assert.assertEquals(Boolean.FALSE, patientResponse.getHasBeenAdmitted());
     }
 
     @Test

--- a/bahmni-commons-api/src/test/java/org/bahmni/module/bahmnicommons/api/contract/patient/mapper/PatientResponseMapperTest.java
+++ b/bahmni-commons-api/src/test/java/org/bahmni/module/bahmnicommons/api/contract/patient/mapper/PatientResponseMapperTest.java
@@ -67,14 +67,18 @@ public class PatientResponseMapperTest {
 
     @Test
     public void shouldMapPatientBasicDetails() throws Exception {
-        patient.setBirthdate(new Date(2000000l));
+        int expectedAge = 54;
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.YEAR, -expectedAge);
+        Date birthDate = cal.getTime();
+        patient.setBirthdate(birthDate);
         patient.setUuid("someUUid");
 
         PatientResponse patientResponse = patientResponseMapper.map(patient, null, null, null, null);
 
         Assert.assertEquals(patientResponse.getPersonId(), 12);
-        Assert.assertEquals(patientResponse.getBirthDate().getTime(), 2000000l);
-        Assert.assertEquals(patientResponse.getAge(), "54");
+        Assert.assertEquals(patientResponse.getBirthDate(), birthDate);
+        Assert.assertEquals(patientResponse.getAge(), Integer.toString(expectedAge));
         Assert.assertEquals(patientResponse.getUuid(), "someUUid");
         Assert.assertEquals(patientResponse.getIdentifier(), "FAN007");
         Assert.assertEquals(patientResponse.getExtraIdentifiers(), "{\"test\" : \"Extra009\"}");


### PR DESCRIPTION
This PR fixes the flaky test `shouldMapPatientBasicDetails` which started failing as the age was calculated based on current date. Instead of setting a fixed birthdate a releative birth date is passed.

Also, the arguments for `assertEquals` method is refactored to be passed in the correc order of `(expected,actual)`